### PR TITLE
Build in Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+os:
+  - linux
+  # osx
+language: c
+install: sudo apt-get install gforth libffi-dev
+script:
+  - ./autogen.sh
+  - ./configure
+  - make


### PR DESCRIPTION
This adds a simple configuration file to build Gforth in [Travis CI](https://travis-ci.org/).
