### PR TITLE
Include shared library in automated build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ before_install:
   - ./install-swig.sh
 script:
   - ./autogen.sh
-  - ./configure
+  - ./configure --enable-lib
   - make


### PR DESCRIPTION
You may also want to enable the shared library in the build.
