### PR TITLE
Build with GCC 4.8 on OS X.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 os:
   - linux
-  # osx
+  - osx
 env:
   - M32=
   - M32=-m32
 language: c
 compiler: gcc
 sudo: true
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install gforth libffi-dev libltdl7 libsoil-dev yodl
-  - if [ `uname -m`$M32 = x86_64-m32 ]; then sudo apt-get --fix-missing install gcc-multilib libltdl7:i386 ; fi
-  - ./install-swig.sh
+before_install: ./install-deps.sh
 script:
   - ./autogen.sh
-  - ./configure --enable-lib CC="gcc $M32"
+  - if [ "${TRAVIS_OS_NAME}" = osx ]; then export CC=gcc-4.8; fi
+  - ./configure --enable-lib CC="$CC $M32"
   - make

--- a/autogen.sh
+++ b/autogen.sh
@@ -20,7 +20,7 @@
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111, USA.
 
-libtoolize --force --copy --install
+libtoolize --force --copy --install || glibtoolize --force --copy --install
 
 # makes a aclocal.m4 which includes the automake macros for autconf
 

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+install_linux() {
+  sudo apt-get update
+  sudo apt-get install gforth libffi-dev libltdl7 libsoil-dev yodl
+  if [ `uname -m`$M32 = x86_64-m32 ]; then
+    sudo apt-get --fix-missing install gcc-multilib libltdl7:i386
+  fi
+}
+
+install_osx() {
+  brew tap zchee/homebrew-zsh
+  brew update > /dev/null
+  brew install yodl
+  brew install gforth
+}
+
+install_${TRAVIS_OS_NAME:-linux}
+./install-swig.sh


### PR DESCRIPTION
If you still want the OS X builld?

Changes:
- Move install script to a file.
- Install OS X dependencies with `brew`.
- Set `CC` to `gcc-4.8` on OS X.  This is the real GCC.
- If `libtoolize` isn't found, fall back to `glibtoolize` which is installed on OS X.
