### PR TITLE
Fix Gforth EC target c165.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - EC=misc
   - EC=r8c
   - EC=8086
+  - EC=c165
 language: c
 compiler: gcc
 sudo: true

--- a/arch/c165/prim.fs
+++ b/arch/c165/prim.fs
@@ -250,17 +250,17 @@ End-Code
 
 
 \ SIO-Grundroutinen                             ( 09.06.96/KK )
-  Code (key?)     ( -- f ) \ Flag, ob Zeichen anliegt
+  Code key?     ( -- f ) \ Flag, ob Zeichen anliegt
     sp -] , tos mov,   tos , 0 s# mov,
     _s0ric . 7 , here 6 + jnb,
     tos , 1 s# sub,   next,                            End-Code
-  Code (key)      ( -- char ) \ Zeichen holen
+  Code key      ( -- char ) \ Zeichen holen
     _s0ric . 7 , here jnb,   _s0ric . 7 bclr,   sp -] , tos mov,
     tosh , 0 s# movb,   tosl , _s0rbuf movb,   next,   End-Code
-  Code (emit?)    ( -- f ) \ Flag, ob Zeichen ausgebbar
+  Code emit?    ( -- f ) \ Flag, ob Zeichen ausgebbar
     sp -] , tos mov,   tos , 0 s# mov,
     _s0tic . 7 , here 6 + jnb,
     tos , 1 s# sub,   next,                            End-Code
-  Code (emit)     ( char -- ) \ Zeichen ausgeben
+  Code emit     ( char -- ) \ Zeichen ausgeben
     _s0tic . 7 , here jnb,   _s0tic . 7 bclr,
     _s0tbuf , tosl movb,   tos , sp ]+ mov,   next,    End-Code


### PR DESCRIPTION
Just renamed terminal I/O primitives.

The other EC targets weren't as easy to fix.