### PR TITLE
No CI build for Gforth EC in macOS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,16 @@ env:
   - EC=misc
   - EC=r8c
   - EC=8086
+matrix:
+  exclude:
+    - os: osx
+      env: EC=misc
+    - os: osx
+      env: EC=r8c
+    - os: osx
+      env: EC=8086
+    - os: osx
+      env: EC=c165
 language: c
 compiler: gcc
 sudo: true


### PR DESCRIPTION
Travis is slow to build in macOS, so this pull request disables all Gforth EC targets for macOS.  They will only be built in Linux.