### PR TITLE
convert c strings into gforth addr u pairs when returning from c-function

### DIFF
--- a/engine/libcc.h
+++ b/engine/libcc.h
@@ -164,6 +164,10 @@ gforth_stackpointers gforth_libcc_init(GFORTH_ARGS)
             : 0); \
   } while (0);
 
+#define c_str2gforth_str(str,addr,u) \
+    (addr) = (Char *) str; \
+    (u) = strlen(str);
+
 #define gforth_ll2ud(ll,lo,hi) \
   do { \
     UClongest _ll = (ll); \

--- a/libcc.fs
+++ b/libcc.fs
@@ -522,6 +522,10 @@ create gen-call-types
 : gen-wrapped-a ( pars c-name fp-change1 sp-change1 -- fp-change sp-change )
     2dup gen-par-sp 2>r ." =(Cell)" gen-wrapped-call 2r> ;
 
+: gen-wrapped-s ( pars c-name fp-change1 sp-change1 -- fp-change sp-change )
+    ." c_str2gforth_str(" gen-wrapped-void
+    ." ," gen-par-sp ." ," gen-par-sp ." )" ;
+
 : gen-wrapped-d ( pars c-name fp-change1 sp-change1 -- fp-change sp-change )
     ." gforth_ll2d(" gen-wrapped-void
     ." ," gen-par-sp ." ," gen-par-sp ." )" ;
@@ -545,7 +549,7 @@ create gen-wrapped-types
 ' gen-wrapped-r ,
 ' gen-wrapped-func ,
 ' gen-wrapped-void ,
-' gen-wrapped-a ,
+' gen-wrapped-s ,
 ' gen-wrapped-a ,
 ' gen-wrapped-void ,
 


### PR DESCRIPTION
Problem:
You can't use return value of wrapped c-function as input to type since the returned string is not a addr u pair as expected by type.

Example:
```
c-library example

\c #include <string.h>

\c char * toUpperCase(char * str) {
\c  const * name = strtok(str,":");
\c
\c  char *s = str;
\c  while (*s) {
\c    *s = toupper((unsigned char) *s);
\c    s++;
\c  }
\c return str;
\c }

c-function to-upper-case toUpperCase s -- s

end-c-library

." Prints HELLO because I added the missing string length:" cr
s" hello" to-upper-case 5 type cr

." Fails because the returned string was not converted to addr u pair:" cr
s" hello" to-upper-case type cr
```

This pull request does not fix wide string return type. I have to look into that later.