### PR TITLE
Cast char * to Cell instead of Char * to suppress compiler warnings

### DIFF
--- a/engine/libcc.h
+++ b/engine/libcc.h
@@ -165,7 +165,7 @@ gforth_stackpointers gforth_libcc_init(GFORTH_ARGS)
   } while (0);
 
 #define c_str2gforth_str(str,addr,u) \
-    (addr) = (Char *) str; \
+    (addr) = (Cell) str; \
     (u) = strlen(str);
 
 #define gforth_ll2ud(ll,lo,hi) \


### PR DESCRIPTION
This pull request suppresses the following warnings:
```
warning: assignment to 'Cell' {aka 'long int'} from 'Char *' {aka 'unsigned char *'} makes integer from pointer without a cast [-Wint-conversion]
  168 |     (addr) = (Char *) str; \
```
Sorry for the inconvenience.