### PR TITLE
arm: beagle: fixes

### DIFF
--- a/arch/arm/beagle/core.c
+++ b/arch/arm/beagle/core.c
@@ -407,7 +407,7 @@ void usbd_tx_complete (struct usb_endpoint_instance *endpoint)
 			endpoint->sent += sent;
 			endpoint->last -= sent;
 
-			if( (endpoint->tx_urb->actual_length - endpoint->sent) <= 0 ) {
+			if (endpoint->sent >= endpoint->tx_urb->actual_length) {
 				tx_urb->actual_length = 0;
 				endpoint->sent = 0;
 				endpoint->last = 0;

--- a/arch/arm/beagle/ep0.c
+++ b/arch/arm/beagle/ep0.c
@@ -192,8 +192,7 @@ static int ep0_get_descriptor (struct usb_device_instance *device,
 
 	/*dbg_ep0(3, "max: %x type: %x index: %x", max, descriptor_type, index); */
 
-	if (!urb || !urb->buffer || !urb->buffer_length
-	    || (urb->buffer_length < 255)) {
+	if (!urb || !urb->buffer || (urb->buffer_length < 255)) {
 		dbg_ep0 (2, "invalid urb %p", urb);
 		return -1L;
 	}

--- a/arch/arm/beagle/usbtty.c
+++ b/arch/arm/beagle/usbtty.c
@@ -711,9 +711,6 @@ static void usbtty_init_instances (void)
 		endpoint_instance[i].tx_packetSize =
 			le16_to_cpu(ep_descriptor_ptrs[i - 1]->wMaxPacketSize);
 
-		endpoint_instance[i].tx_attributes =
-			ep_descriptor_ptrs[i - 1]->bmAttributes;
-
 		urb_link_init (&endpoint_instance[i].rcv);
 		urb_link_init (&endpoint_instance[i].rdy);
 		urb_link_init (&endpoint_instance[i].tx);


### PR DESCRIPTION
In core.c fixes a nontrivial unsigned int checking expression.
In ep0.c removes a redundant condition.
In usbtty.c removes a duplicate assignment.

Signed-off-by: Geyslan G. Bem <geyslan@gmail.com>