### PR TITLE
Moved AC_CHECK_FUNCS(dlopen) above the first usage of $ac_cv_func_dlopen

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1152,6 +1152,7 @@ fi
 AC_SUBST(LIB_SUFFIX)
 AC_CHECK_LIB(rt,clock_gettime)
 
+AC_CHECK_FUNCS(dlopen)
 if test -n "$GNU_LIBTOOL" -a "x$ac_cv_lib_ltdl_lt_dlinit" = xyes; then
   build_libcc_named=build-libcc-named
 elif test -n "$GNU_LIBTOOL" -a "x$ac_cv_func_dlopen" = xyes; then
@@ -1220,7 +1221,7 @@ AC_HEADER_STDC
 AC_CHECK_LIB(dl,dlopen)
 AC_REPLACE_FUNCS(memmove strtoul exp10 sincos strerror strsignal atanh)
 AC_FUNC_FSEEKO
-AC_CHECK_FUNCS(ftello dlopen sys_siglist getrusage nanosleep clock_gettime)
+AC_CHECK_FUNCS(ftello sys_siglist getrusage nanosleep clock_gettime)
 AC_CHECK_TYPES(stack_t,,,[#include <signal.h>])
 AC_DECL_SYS_SIGLIST
 AC_CHECK_FUNC(getopt_long,[true],[AC_LIBOBJ(getopt) AC_LIBOBJ(getopt1)])


### PR DESCRIPTION
This fixes OS X MacPorts build for me.