### PR TITLE
fix latest-name, simplify latest-name-in

### DIFF
--- a/latest-name.fs
+++ b/latest-name.fs
@@ -20,9 +20,9 @@
 
 : latest-name-in ( wid -- nt|0 ) \ gforth-experimental
     \G return the latest name defined in a vocabulary or 0 if none
-    { | w^ result }
-    result [{: r :}l r ! false ;] swap traverse-wordlist
-    result @ ;
-: latest-name ( -- nt|0 ) \ gforth-experimental
-    \G return the @code{LATEST-NAME-IN} in the current wordlist
-    get-current latest-name-in ;
+    0 [: nip false ;] rot traverse-wordlist ;
+
+: latest-name ( -- nt ) \ gforth-experimental
+    \G return the @code{LATEST-NAME-IN} for the compilation wordlist
+    \G if it is not empty, or throw an exception otherwise.
+    get-current latest-name-in dup 0= -80 and throw ;

--- a/minos2/wayland-gl.fs
+++ b/minos2/wayland-gl.fs
@@ -136,7 +136,7 @@ ${GFORTH_IGNLIB} "true" str= [IF]
 	record-name (cb') drop ['] drop nr> drop ;
 [ELSE]
     : cb! ( xt callback offset -- )
-	>r execute get-current latest-name-in r> execute ! ;
+	>r execute latest-name r> execute ! ;
     : cb-pair ( "name" -- callback offset )
 	record-name >in @ >r (cb') r> >in ! (cb#) ;
     : ?cb ( xt "name" -- ) cb-pair cb! ;

--- a/minos2/wayland-presentation.fs
+++ b/minos2/wayland-presentation.fs
@@ -145,7 +145,7 @@ Create xdg-wm-base-listener xdg_wm_base_listener allot
     serial( dup [: cr ." pong serial: " h. ;] do-debug )
     dup to last-serial
     xdg_wm_base_pong drop ; xdg_wm_base_listener-ping:
-    get-current latest-name-in xdg_wm_base_listener-ping !
+    latest-name xdg_wm_base_listener-ping !
 ```
 	\sans
     }}v box[] >bdr


### PR DESCRIPTION
Make `latest-name` operate on the compilation word list (as per the proposal [311]) rather than the topmost word list in the search order.

Simplify the implementation of `latest-name-in`.

When possible, use `latest-name` instead of `latest-name-in`.