### PR TITLE
Correct the recognizer for string literals

### DIFF
--- a/rec-string.fs
+++ b/rec-string.fs
@@ -24,7 +24,21 @@ s" Scanned string not in input buffer" exception >r
     bounds source bounds swap 1+ 2tuck within >r within r> and
     0= IF  [ r> ]L throw  THEN ;
 
+: (unescape) ( addr1 u1 -- addr.transient u2 flag )
+    here >r bounds begin  2dup u> while
+        count dup '\' <> if c, else drop \-escape, then
+    repeat = ( flag )
+    r> here over -  dup negate allot  rot ;
+
+: decode-string-literal ( addr1 u1 -- addr1 u1 false | addr2 u2 true )
+    dup 2 < if false exit then
+    2dup s\" \"" string-suffix? invert if false exit then
+    2dup s\" \"" string-prefix? invert if false exit then
+    2dup 1 /string char- (unescape) invert if 2drop false exit then ( sd1 sd )
+    2nip save-mem true ;
+
 : scan-string ( addr u -- addr' u' )
+    decode-string-literal if exit then
     2dup ?in-inbuf
     drop source drop - 1+ >in !
     ['] multiline-string \"-parse  save-mem ;


### PR DESCRIPTION
Fixes #25

The word `scan-string` now returns an unquoted and decoded character string without scanning the input source for the tail of a string literal if its input string parameter starts and ends with '"'.

Note: to correctly check that the input string parameter ends with '"', the back-slash-escaping should be decoded the same way as the multiline string parser in Gforth does.